### PR TITLE
claude/session-011CUYeVyYt4fW75m3zu3rFE

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ There is still a lot TODO, i'll get around to it as I need it :)
 ### Linux / MacOS
 
 ```bash
-curl -fsSL git.io/fpEqU | bash
+curl -fsSL https://raw.githubusercontent.com/csi-lk/gg/master/install.sh | bash
+```
+
+Or clone and run locally:
+
+```bash
+git clone https://github.com/csi-lk/gg.git
+cd gg
+bash install.sh
 ```
 
 ## Usage

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,82 @@
+#!/bin/bash
+set -e
+
 green() {
-	printf "\e[0;32m$1\e[0m"
+	printf "\e[0;32m$1\e[0m\n"
+}
+
+red() {
+	printf "\e[0;31m$1\e[0m\n"
+}
+
+yellow() {
+	printf "\e[0;33m$1\e[0m\n"
 }
 
 install() {
-	echo $(green "Downloading script...")
-	curl -L#o /var/tmp/gg_$$ https://raw.githubusercontent.com/csi-lk/gg/master/bin/gg
-    echo $(green "Setting permissions...")
-	chmod -v +x /var/tmp/gg_$$
-    echo $(green "Moving to \$PATH")
-	sudo mv -fv /var/tmp/gg_$$ /usr/local/bin/gg
-	version=($(gg -V))
-	echo $(green "Successfully installed! v${version}")
+	local tmp_file="/tmp/gg_$$"
+	local install_dir=""
+
+	echo "$(green "Downloading gg script...")"
+	if ! curl -fsSL -o "$tmp_file" https://raw.githubusercontent.com/csi-lk/gg/master/bin/gg; then
+		echo "$(red "Failed to download script")"
+		exit 1
+	fi
+
+	echo "$(green "Setting permissions...")"
+	chmod +x "$tmp_file"
+
+	# Try to install to /usr/local/bin first (preferred location)
+	if [ -w /usr/local/bin ]; then
+		install_dir="/usr/local/bin"
+		mv -f "$tmp_file" "$install_dir/gg"
+		echo "$(green "Installed to $install_dir/gg")"
+	elif [ -d /usr/local/bin ] && [ "$(id -u)" != "0" ]; then
+		# Try with sudo if directory exists but not writable
+		echo "$(yellow "/usr/local/bin requires sudo access...")"
+		if sudo -n true 2>/dev/null; then
+			# sudo available without password
+			sudo mv -f "$tmp_file" /usr/local/bin/gg
+			install_dir="/usr/local/bin"
+			echo "$(green "Installed to $install_dir/gg")"
+		elif read -p "Install to /usr/local/bin with sudo? [y/N] " -n 1 -r; then
+			echo
+			if [[ $REPLY =~ ^[Yy]$ ]]; then
+				sudo mv -f "$tmp_file" /usr/local/bin/gg
+				install_dir="/usr/local/bin"
+				echo "$(green "Installed to $install_dir/gg")"
+			else
+				install_dir=""
+			fi
+		else
+			install_dir=""
+		fi
+	fi
+
+	# Fallback to ~/.local/bin
+	if [ -z "$install_dir" ]; then
+		install_dir="$HOME/.local/bin"
+		echo "$(yellow "Installing to $install_dir instead...")"
+		mkdir -p "$install_dir"
+		mv -f "$tmp_file" "$install_dir/gg"
+		echo "$(green "Installed to $install_dir/gg")"
+
+		# Check if ~/.local/bin is in PATH
+		if [[ ":$PATH:" != *":$install_dir:"* ]]; then
+			echo "$(yellow "⚠ Warning: $install_dir is not in your PATH")"
+			echo "Add the following line to your ~/.bashrc or ~/.zshrc:"
+			echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+		fi
+	fi
+
+	# Verify installation
+	if command -v gg &> /dev/null; then
+		version=$(gg -V 2>/dev/null || echo "unknown")
+		echo "$(green "Successfully installed! $version")"
+	else
+		echo "$(yellow "Installation complete, but 'gg' not found in PATH")"
+		echo "You may need to restart your shell or run: hash -r"
+	fi
 }
 
 install


### PR DESCRIPTION
…bility

- Add proper error handling with set -e and curl error checking
- Smart installation location detection (tries /usr/local/bin, falls back to ~/.local/bin)
- Optional sudo prompt instead of requiring it
- Better user feedback with colored output (green/yellow/red)
- PATH verification and helpful instructions if gg not in PATH
- Fix deprecated git.io URL in README (GitHub discontinued the service in 2022)
- Add alternative installation method (clone and run locally)
- Use proper shebang (#!/bin/bash)
- Improved temp file location (/tmp instead of /var/tmp)

This should fix the issue where users had to install manually due to sudo requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)