### PR TITLE
feat: add `gg up` self-upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ bash install.sh
 | gg t              | create a tag                                                |
 | gg td `<name>`    | delete a tag `<name>`                                       |
 | gg z `<commands>` | combo commands, eg. `gg z a c p` for `gg a && gg c && gg p` |
+| gg up             | check for and install the latest version                    |
 
 ## Development
 

--- a/bin/gg
+++ b/bin/gg
@@ -6,6 +6,9 @@ set -uo pipefail
 
 VERSION="1.1.0"
 
+REMOTE_GG_URL="https://raw.githubusercontent.com/csi-lk/gg/master/bin/gg"
+INSTALL_URL="https://raw.githubusercontent.com/csi-lk/gg/master/install.sh"
+
 # Colors and formatting
 # --------------------------------------------------------------------
 # Use %b so callers can pass "\n" etc, while the text itself is treated
@@ -120,6 +123,35 @@ unknown_command() {
 
 version() {
 	printf 'gg version %s\n' "$VERSION"
+}
+
+remote_version() {
+	# Print the VERSION="x.y.z" value from bin/gg on master, or empty on failure.
+	curl -fsSL "$REMOTE_GG_URL" 2>/dev/null |
+		grep -m1 '^VERSION=' |
+		sed -E 's/^VERSION="?([^"]*)"?/\1/'
+}
+
+upgrade() {
+	if ! command -v curl &>/dev/null; then
+		red "curl is required to upgrade gg\n"
+		grey "  Install manually: $INSTALL_URL\n"
+		exit 1
+	fi
+	green "Checking for updates...\n"
+	local latest
+	latest=$(remote_version)
+	if [ -z "$latest" ]; then
+		red "Couldn't reach GitHub to check for updates\n"
+		exit 1
+	fi
+	if [ "$latest" == "$VERSION" ]; then
+		green "gg is up to date (v$VERSION)\n"
+		return
+	fi
+	yellow "Update available: $VERSION → $latest\n"
+	green "Upgrading...\n"
+	curl -fsSL "$INSTALL_URL" | bash
 }
 
 init() {
@@ -435,6 +467,7 @@ display_help() {
 		$(green "gg") $(yellow "t")            $(grey "|") create a tag
 		$(green "gg") $(yellow "td <name>")    $(grey "|") delete a tag <name>
 		$(green "gg") $(yellow "z <commands>") $(grey "|") combo commands, eg. gg z a c p for gg a && gg c && gg p
+		$(green "gg") $(yellow "up")           $(grey "|") check for and install the latest version
 		$(green "gg") $(yellow "-V")           $(grey "|") print version
 
 	EOF
@@ -506,6 +539,7 @@ else
 			combo "$@"
 			exit
 			;;
+		up | upgrade | update) upgrade ;;
 		-V | --version) version ;;
 		-h | h | --help | help) display_help ;;
 		*)

--- a/test/gg.bats
+++ b/test/gg.bats
@@ -285,3 +285,13 @@ teardown() {
     assert_success
     assert_line --partial "gg version"
 }
+
+@test "Upgrade: is a recognised command" {
+    # Stub curl to fail so we hit the offline guard instead of the network
+    curl() { return 1; }
+    export -f curl
+    run gg up
+    assert_failure
+    refute_line --partial "Unknown command"
+    assert_line --partial "Couldn't reach GitHub"
+}


### PR DESCRIPTION
## What

Adds a `gg up` command (aliases: `upgrade`, `update`) that checks whether the locally-installed `gg` is behind the latest published version and upgrades it in place.

## How

- `remote_version()` fetches `bin/gg` from `master` and extracts its `VERSION=` string — the same source `install.sh` already uses, so no releases/tags are required (the repo has none).
- `upgrade()`:
  - Requires `curl`; otherwise prints a clear message + the manual install URL and exits.
  - Compares local `VERSION` against master. Equal → "gg is up to date". Behind → shows `Update available: X → Y` and re-runs the canonical `install.sh`, reusing its existing install-location / sudo / PATH logic rather than duplicating it.
  - Fails cleanly (exit 1) when GitHub is unreachable.
- Wired into the dispatcher and `display_help`; added to the README command table.

## Design note

The check is a simple **string equality** against `master`, not semver ordering — if local ≠ master, an upgrade is offered. `gg up` therefore tracks the tip of `master`. If tagged releases are introduced later, this can be swapped to the Releases API.

## Testing

- `shellcheck bin/gg install.sh` — clean
- `yarn test` (bats) — 32/32 pass, including a new offline test that stubs `curl` to fail and asserts the "Couldn't reach GitHub" guard path
- Manual: up-to-date path prints `gg is up to date (v1.1.0)`; behind path (faked local `VERSION=0.0.0`) prints `Update available: 0.0.0 → 1.1.0` and invokes the installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)